### PR TITLE
Exclude misleading files for VS Code learners

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,8 @@
+{
+        "files.exclude": {
+            "**/bin": true
+            "**/.gradle": true
+            "**/gradle": true
+            "**/*.lock": true
+        }
+}


### PR DESCRIPTION
VS Code's Java integration makes _copies_ of some source files in /bin/ which will [mislead learners into editing the wrong file](https://github.com/redhat-developer/vscode-java/issues/634). This tells VS Code (at least) to ignore those files.