### PR TITLE
Change exercise docker-compose.yml to reference Github-hosted images

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -31,7 +31,7 @@ jobs:
         uses: docker/setup-buildx-action@v2
 
       - name: Log in to the Container registry
-        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        uses: docker/login-action@v2
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -50,15 +50,15 @@ jobs:
       - name: Print outputs
         run: echo "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/${{ steps.docker_name.outputs.replaced }}"
 
-#      - name: Build and push Docker image
-#        uses: docker/build-push-action@v3
-#        with:
-#          build-args: |
-#            release=${{ github.ref_name }}
-#          context: ${{ matrix.docker_context }}
-#          platforms: linux/amd64, linux/arm64
-#          push: true
-#          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-#${{ steps.meta.outputs.tags }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v3
+        with:
+          build-args: |
+            release=${{ github.ref_name }}
+          context: ${{ matrix.docker_context }}
+          platforms: linux/amd64, linux/arm64
+          push: true
+          tags: "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/${{ steps.docker_name.outputs.replaced }}:latest"
 #          labels: ${{ steps.meta.outputs.labels }}
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -11,10 +11,8 @@ jobs:
       matrix:
         docker_context:
           - introduction_to_apis/stock_management_server
-          - introduction_to_rest_apis/stock_management_server_1
-          - introduction_to_rest_apis/stock_management_server_2
-          - introduction_to_rest_apis/stock_management_client_1
-          - introduction_to_rest_apis/stock_management_client_2
+          - introduction_to_rest_apis/stock_management_server
+          - introduction_to_rest_apis/stock_management_client
           - request_design
 
     runs-on: ubuntu-latest

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -7,6 +7,15 @@ env:
 
 jobs:
   build-and-push-image:
+    strategy:
+      matrix:
+        docker_context:
+          - request_design
+          - introduction_to_rest_apis/stock_management_server_1
+          - introduction_to_rest_apis/stock_management_server_2
+          - introduction_to_rest_apis/stock_management_client_1
+          - introduction_to_rest_apis/stock_management_client_2
+
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -29,26 +38,26 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Docker meta
-        id: meta
-        uses: docker/metadata-action@v4
+      - name: Generate basis for Docker image
+        id: docker_name
+        uses: frabert/replace-string-action@v2
         with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          tags: |
-            type=semver,pattern={{version}}
-            type=ref,event=branch
-            type=sha
-
-      - name: Build and push Docker image
-        uses: docker/build-push-action@v3
-        with:
-          build-args: |
-            release=${{ github.ref_name }}
-          context: .
-          platforms: linux/amd64, linux/arm64
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+          string: ${{ matrix.docker_context }}
+          pattern: '/'
+          replace-with: '_'
 
       - name: Print outputs
-        run: echo "${{ steps.meta.outputs.tags }}"
+        run: echo "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/${{ steps.docker_name.outputs.replaced }}"
+
+#      - name: Build and push Docker image
+#        uses: docker/build-push-action@v3
+#        with:
+#          build-args: |
+#            release=${{ github.ref_name }}
+#          context: ${{ matrix.docker_context }}
+#          platforms: linux/amd64, linux/arm64
+#          push: true
+#          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+#${{ steps.meta.outputs.tags }}
+#          labels: ${{ steps.meta.outputs.labels }}
+

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,54 @@
+name: Build and publish a Docker image
+on: push
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=ref,event=branch
+            type=sha
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v3
+        with:
+          build-args: |
+            release=${{ github.ref_name }}
+          context: request_design
+          platforms: linux/amd64, linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Print outputs
+        run: echo ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -10,11 +10,12 @@ jobs:
     strategy:
       matrix:
         docker_context:
-          - request_design
+          - introduction_to_apis/stock_management_server
           - introduction_to_rest_apis/stock_management_server_1
           - introduction_to_rest_apis/stock_management_server_2
           - introduction_to_rest_apis/stock_management_client_1
           - introduction_to_rest_apis/stock_management_client_2
+          - request_design
 
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -44,7 +44,7 @@ jobs:
         with:
           build-args: |
             release=${{ github.ref_name }}
-          context: request_design
+          context: .
           platforms: linux/amd64, linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -51,4 +51,4 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
 
       - name: Print outputs
-        run: echo ${{ steps.meta.outputs.tags }}
+        run: echo "${{ steps.meta.outputs.tags }}"

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -42,6 +42,7 @@ jobs:
         id: docker_name
         uses: frabert/replace-string-action@v2
         with:
+          flags: g
           string: ${{ matrix.docker_context }}
           pattern: '_'
           replace-with: '-'

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -38,17 +38,16 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-#      - name: Generate basis for Docker image
-#        id: docker_name
-#        uses: frabert/replace-string-action@v2
-#        with:
-#          string: ${{ matrix.docker_context }}
-#          pattern: '_'
-#          replace-with: '-'
+      - name: Generate basis for Docker image
+        id: docker_name
+        uses: frabert/replace-string-action@v2
+        with:
+          string: ${{ matrix.docker_context }}
+          pattern: '_'
+          replace-with: '-'
 
       - name: Print outputs
-        run: echo "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/${{ matrix.docker_context }}"
-#        run: echo "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/${{ steps.docker_name.outputs.replaced }}"
+        run: echo "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/${{ steps.docker_name.outputs.replaced }}"
 
 #      - name: Build and push Docker image
 #        uses: docker/build-push-action@v3

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -38,16 +38,17 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Generate basis for Docker image
-        id: docker_name
-        uses: frabert/replace-string-action@v2
-        with:
-          string: ${{ matrix.docker_context }}
-          pattern: '/'
-          replace-with: '_'
+#      - name: Generate basis for Docker image
+#        id: docker_name
+#        uses: frabert/replace-string-action@v2
+#        with:
+#          string: ${{ matrix.docker_context }}
+#          pattern: '_'
+#          replace-with: '-'
 
       - name: Print outputs
-        run: echo "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/${{ steps.docker_name.outputs.replaced }}"
+        run: echo "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/${{ matrix.docker_context }}"
+#        run: echo "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/${{ steps.docker_name.outputs.replaced }}"
 
 #      - name: Build and push Docker image
 #        uses: docker/build-push-action@v3

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 .gradle
-
 !gradle-wrapper.jar
+**/bin/*
+*.bin
+*.lock
+*.log

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,1 +1,0 @@
-FROM alpine

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,1 @@
+FROM alpine

--- a/introduction_to_apis/docker-compose.yml
+++ b/introduction_to_apis/docker-compose.yml
@@ -15,8 +15,7 @@ services:
     tty: true
     stdin_open: true
   dev-server:
-    build:
-      context: "./stock_management_server"
+    image: ghcr.io/skiller-whale/rest-api-design-in-kotlin/introduction-to-apis/stock-management-server
     ports:
       - "7070:7070"
     volumes:

--- a/introduction_to_rest_apis/docker-compose.yml
+++ b/introduction_to_rest_apis/docker-compose.yml
@@ -16,15 +16,13 @@ services:
     tty: true
     stdin_open: true
   stock_management_server:
-    build:
-      context: "./stock_management_server"
+    image: ghcr.io/skiller-whale/rest-api-design-in-kotlin/introduction-to-rest-apis/stock-management-server
     ports:
       - "7070:7070"
     volumes:
       - "./stock_management_server/src:/app/src"
   stock_management_client:
-    build:
-      context: "./stock_management_client"
+    image: ghcr.io/skiller-whale/rest-api-design-in-kotlin/introduction-to-rest-apis/stock-management-client
     ports:
       - "7071:7071"
     volumes:

--- a/request_design/docker-compose.yml
+++ b/request_design/docker-compose.yml
@@ -15,8 +15,7 @@ services:
     tty: true
     stdin_open: true
   dev-server:
-    build:
-      context: .
+    image: ghcr.io/skiller-whale/rest-api-design-in-kotlin/request-design
     ports:
       - "7070:7070"
     volumes:


### PR DESCRIPTION
This branch should stop learners from having to build exercise images on their own machines.

It removes the `build:` clause from `docker-compose.yml` in favour of referencing images on `ghcr.io`, and supplies a Github workflow file that seems to build them all OK (eventually, seems to take about 20 minutes, but it builds simultaneously).

When adding a new Dockerfile to the repo that you want built, you just need to add it to the list at the top of the `.github/actions/docker.yml` file and e.g. if you list `request_design` the image should end up hosted at `ghcr.io/skiller-whale/rest-api-design-in-kotlin/request_design` (any number of slashes is allowed in Docker image names, apparently).

NB 1 when learners update the Git repository at the start of the session they may have to run `docker compose pull` to refresh their image.

NB 2 any push on any branch will trigger Github to rebuild and tag it that image as `latest`, so there is a potential for clashes if we're pushing new branches as learners are starting sessions. 

My preferred solution to both of these NBs is that `docker-compose.yml` file references images by SHA1 (i.e. suffix the Docker image with `:1234abc...` rather than the currently-implied `:latest`). That way whatever ends up on `main` is what they pull, and references the corresponding image automatically. But I still have to work out how to make that happen.