### PR TITLE
Add .gitattributes to ensure gradlew isn't corrupted on checkout on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+* text=auto
+gradlew text eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,1 @@
-* text=auto
 gradlew text eol=lf


### PR DESCRIPTION
Because `gradlew` is a Linux shell script, which much start with `#!/bin/sh␊` but if you `git checkout` the repository on Windows, `git`'s default is to assume the text file is going to run on Windows so it translates it to `#!/bin/sh␍␊`. When you run `docker build` that CR-LF mangled version goes to Linux, which says "not found" because the shebang line is invalid.

So I think this change tells Git to not do that mangling for this one specific file, but it's quite hard to test without merging because Git does the translation on first checkout :)

This PR is made practically redundant by https://github.com/skiller-whale/rest-api-design-in-kotlin/pull/4 but would be essential for someone developing on Windows proper.